### PR TITLE
Add JSON-LD island output to templates

### DIFF
--- a/_layouts/bare.html
+++ b/_layouts/bare.html
@@ -9,6 +9,10 @@
     <meta name="screen-orientation" content="portrait" />
     <meta name="full-screen" content="yes" />
     <meta name="description" content="The mission of the JSON-LD Working Group is to update the JSON-LD 1.0 specifications to address specific usability or technical issues based on the community's experiences, implementer feedback, and requests for new features." />
+    {% if page.json-ld %}
+    <script type="application/ld+json">{{ page.json-ld }}</script>
+    {% endif %}
+
     <link rel="stylesheet" href="https://www.w3.org/2018/json-ld-wg/assets/css/style.css">
     <!--[if lt IE 9]>
     <script src="//html5shiv.googlecode.com/svn/trunk/html5.js"></script>

--- a/_layouts/default.html
+++ b/_layouts/default.html
@@ -9,6 +9,10 @@
     <meta name="screen-orientation" content="portrait" />
     <meta name="full-screen" content="yes" />
     <meta name="description" content="The mission of the JSON-LD Working Group is to update the JSON-LD 1.0 specifications to address specific usability or technical issues based on the community's experiences, implementer feedback, and requests for new features." />
+    {% if page.json-ld %}
+    <script type="application/ld+json">{{ page.json-ld }}</script>
+    {% endif %}
+
     <link rel="stylesheet" href="https://www.w3.org/2018/json-ld-wg/assets/css/style.css">
     <link rel="stylesheet" href="https://www.w3.org/2018/json-ld-wg/css/style-extras.css">
     <!--[if lt IE 9]>

--- a/_layouts/home.html
+++ b/_layouts/home.html
@@ -9,6 +9,10 @@
     <meta name="screen-orientation" content="portrait" />
     <meta name="full-screen" content="yes" />
     <meta name="description" content="The mission of the JSON-LD Working Group is to update the JSON-LD 1.0 specifications to address specific usability or technical issues based on the community's experiences, implementer feedback, and requests for new features." />
+    {% if page.json-ld %}
+    <script type="application/ld+json">{{ page.json-ld }}</script>
+    {% endif %}
+
     <link rel="stylesheet" href="https://www.w3.org/2018/json-ld-wg/assets/css/style.css">
     <!--[if lt IE 9]>
     <script src="//html5shiv.googlecode.com/svn/trunk/html5.js"></script>

--- a/_layouts/minutes.html
+++ b/_layouts/minutes.html
@@ -9,6 +9,10 @@
     <meta name="screen-orientation" content="portrait" />
     <meta name="full-screen" content="yes" />
     <meta name="description" content="The mission of the JSON-LD Working Group is to update the JSON-LD 1.0 specifications to address specific usability or technical issues based on the community's experiences, implementer feedback, and requests for new features." />
+    {% if page.json-ld %}
+    <script type="application/ld+json">{{ page.json-ld }}</script>
+    {% endif %}
+
     <link rel="stylesheet" href="https://www.w3.org/2018/json-ld-wg/assets/css/style.css">
     <!--[if lt IE 9]>
     <script src="//html5shiv.googlecode.com/svn/trunk/html5.js"></script>

--- a/index.md
+++ b/index.md
@@ -1,5 +1,28 @@
 ---
 layout: home
+json-ld: |
+  {"@context": "http://schema.org/",
+   "@type": "Organization",
+   "name": "JSON-LD Working Group",
+   "member": {
+    "@type": "OrganizationRole",
+    "roleName": "Co-Chair",
+    "member": [
+      {"@type": "Person",
+       "name": "Rob Sanderson",
+       "email": "azaroth42@gmail.com"},
+      {"@type": "Person",
+       "name": "Benjamin Young",
+       "email": "byoung@bigbluehat.com"}
+     ]
+   },
+   "contactPoint": {
+     "@type": "ContactPoint",
+     "name": "Ivan Herman",
+     "email": "ivan@w3.org",
+     "contactType": "W3C Staff Contact"
+   }
+  }
 ---
 
 The mission of the JSON-LD Working Group is to update the [JSON-LD 1.0](https://www.w3.org/TR/2014/REC-json-ld-20140116/) specifications to address specific usability or technical issues based on the community's experiences, implementer feedback, and requests for new features.


### PR DESCRIPTION
Also adds Org info to index.md

This will allow us (as wanted) to include JSON-LD content in the head of our docs.

I'd originally played with RDFa encoding in this commit https://github.com/w3c/json-ld-wg/commit/fbc44db70b6376e1375871dbd467ee9dcb1c03ff but the confluence of Liquid template's handling of whitespace along with the idiosyncratic include system made both the input and the output less than awesome...

At any rate, this has some cool value adds to the site...and it's JSON-LD!!1! 😁 