### PR TITLE
Add principles to website

### DIFF
--- a/WorkMode/guiding_principles.md
+++ b/WorkMode/guiding_principles.md
@@ -1,0 +1,86 @@
+---
+layout: default
+---
+
+# JSON-LD Working Group Guiding Principles
+{: .no_toc}
+
+This document sets down the current guiding principles in use by the JSON-LD 1.1 Working Group to assist in making decisions about specification features. These guidelines provide a framework in which to have productive discussions that quickly come to consensus, rather than ending up blocked in an unresolvable tug-of-war over opposing and equally valid points of view. The principles are not meant to be interpreted as strict or objective rules, but instead as informative of the overall direction of the group to promote consistency and usability of the resulting specifications. 
+
+This document is a *Living Document* and as such will change. Members of the group are encouraged to edit (e.g. to update, correct, etc.) the information. Comments about this document are welcome via issues and pull request on the [group’s “admin” repository](https://github.com/w3c/json-ld-wg/) or via emails sent to the group’s [`public-json-ld-wg@w3.org`](mailto:public-json-ld-wg@w3.org) e-mail list, using a subject prefix of <code>[Principles] …</code>.
+
+**Table of Content**
+* TOC
+{:toc}
+
+---
+
+## Stay on target!
+
+We follow our overall mission of making production and consumption of the JSON serialized data as easy as possible for the widest variety of developers, with or without any experience of any underlying graph models.
+
+**Notes**
+
+* The target audience is software developers generally, not just those that build browser-based applications.
+* There may be a need to priotize between production of the JSON or consumption of the JSON, as clarified further below, but the intent is that solutions should be balanced as both producers and consumers are required for the ecosystem to be successful.
+* JSON-centric or RDF-graph-centric need to be balanced as well, to ensure both usability and technical functionality
+
+## Require real use cases, with actual instance data.
+
+Features are supported by real world use cases, with actual data that can be referenced. This helps reduce entirely theoretical features that might be implemented in libraries, but never used in practice by producers or consumers.
+
+**Notes**
+
+* Use cases should be supporting material to provide rationale for decisions, and a teaching tool for when features might be useful. They are not a design requirements gathering tool, and the group is not starting from an empty slate.
+* These use cases are collected on a wiki page, with the option of publishing a Note or integrating in to the specifications.
+
+## Require at least two supporters for each use case.
+
+As the mission is interoperability, having at least two supporters for each use case is important. If only one supporter can be found, then any features that it would require are likely too specific for inclusion in the proposed form.
+
+**Notes**
+
+* Any independent organization, group or individual can be a supporter, regardless of whether they are part of the Working Group, or even members of the W3C. Consortia or other standards organizations that represent many participants can thus fulfill this principle via their members.
+* This is orthogonal to implementations of the specifications, which are required to exit Candidate Recommendation phase.
+
+## As simple as possible, but no simpler.
+
+A simpler solution (to understand, implement and use) is better than a more complex solution that accomplishes the same result.
+
+## Consistency is simpler than exceptions.
+
+Simplicity is considered in aggregate for the set of features defined by a specification, not independently.  If the same set of features can be accomplished by a smaller number of more consistent patterns, then that method is (very likely) simpler. Memorizing exceptions is harder than memorizing and applying rules.
+
+**Notes**
+
+* The WG discussed up to this point on 2018-07-06.
+
+## Simplicity is determined by end users, not library implementers.
+
+Simplicity (or usability) is determined by the target audience (data producers and consumers) based on their experience of understanding and applying the specification via existing implementations, not by the experience of implementers of the specification text directly. If there is a feature that makes it harder for implementations, but easier/better for end users, then that is a worthwhile trade off.
+
+## Provide on-ramps.
+
+A solution that can be implemented in incremental stages is better than a
+solution that is all or nothing, as not everyone needs every feature but
+many people need various parts.
+
+## Define success, not failure.
+
+We should define things in terms of what it means to be conformant, rather
+than what is not conformant.  The fewer constraints we require, the easier
+to have non-breaking changes in the future and the easier it is to have
+experimentation.
+
+## Follow existing standards and best practices, where possible and where they do not conflict with other principles.
+
+Between invention and reuse, pick reuse... unless that reuse would
+demonstrably harm adoption by being more complicated than necessary.
+
+## The underlying data model is RDF.
+
+If a feature comes up that can't be modeled with RDF as the underlying abstract data model, then we refer the feature to a future RDF Working Group for potential inclusion at that time. Similarly, we should ensure that the features of RDF are expressed in JSON-LD, to ensure that data can be round-tripped with confidence through different serializations.
+
+**Notes**
+
+* Objections: There is a more generic data model in JSON-LD, and we have the flexibility to add to it if we want to as long as we're not breaking backwards compatibility with JSON-LD 1.0. We don't want to box ourselves into a corner that will prevent us from thinking creatively about solutions.

--- a/WorkMode/guiding_principles.md
+++ b/WorkMode/guiding_principles.md
@@ -51,36 +51,39 @@ A simpler solution (to understand, implement and use) is better than a more comp
 
 Simplicity is considered in aggregate for the set of features defined by a specification, not independently.  If the same set of features can be accomplished by a smaller number of more consistent patterns, then that method is (very likely) simpler. Memorizing exceptions is harder than memorizing and applying rules.
 
+## Usability is determined by end users, not library implementers.
 
-`The WG discussed up to this point on 2018-07-06.`
-<!-- Is there a {: .note} or similar? -->
+Usability is determined by the target audience (data producers and consumers) based on their experience of understanding and applying the specification via existing implementations, not by the experience of implementers of the specification text directly. If there is a feature that makes it harder for implementations, but easier/better for end users, then that is a worthwhile trade off. We follow the HTML Design Pattern documents notion of the [Priority of Constituencies](https://www.w3.org/TR/html-design-principles/#priority-of-constituencies), with an emphasis on trying to make things better for everyone. 
 
-## Proposed: Simplicity is determined by end users, not library implementers.
+**Notes**
 
-Simplicity (or usability) is determined by the target audience (data producers and consumers) based on their experience of understanding and applying the specification via existing implementations, not by the experience of implementers of the specification text directly. If there is a feature that makes it harder for implementations, but easier/better for end users, then that is a worthwhile trade off.
+* Issues might arise where we need to prioritize between producers and consumers of the JSON-LD. The general feeling is that, in that situation, we should prioritize consumer happiness over producer happiness... the usability of the data, rather than ease of creation.
+* The WG is explicitly unopinionated about the many JSON API design patterns that have arisen. We endeavour to allow the context and frame designers to be as specific as possible, to ensure that compaction and framing algorithms can produce the precise structure desired, avoiding having to post-process the resulting JSON.
 
-## Proposed: Provide on-ramps.
+## Provide on-ramps.
 
 A solution that can be implemented in incremental stages is better than a
 solution that is all or nothing, as not everyone needs every feature but
-many people need various parts.
+many people need various parts. Complex patterns should build upon simple ones, sometimes making them patterns more complicated than if they were built in isolation.
 
-## Proposed: Define success, not failure.
+## Define success, not failure.
 
-We should define things in terms of what it means to be conformant, rather
-than what is not conformant.  The fewer constraints we require, the easier
-to have non-breaking changes in the future and the easier it is to have
-experimentation.
+The specifications are defined in terms of what it means to be conformant, and not patterns that are not conformant.  The fewer constraints we require, the easier to have non-breaking changes in the future and the easier it is to have experimentation. In a similar way to the distinction between Open World and Closed World, if something is not defined by the specification then it is permissible (just not standardized) rather than being disallowed.
 
-## Proposed: Follow existing standards and best practices, where possible and where they do not conflict with other principles.
+**Notes**
+* This is hard to judge when it is appropriate to be prescriptive, and when it is appropriate to be silent. Several issues have arisen on both sides -- sometimes 1.0 is too prescriptive, sometimes the definition is not precise enough.
+
+## Follow existing standards and best practices, where possible and where they do not conflict with other principles.
 
 Between invention and reuse, pick reuse... unless that reuse would
 demonstrably harm adoption by being more complicated than necessary.
 
-## Proposed: The underlying data model is RDF.
+## New features should be compatible with the RDF Data Model.
 
-If a feature comes up that can't be modeled with RDF as the underlying abstract data model, then we refer the feature to a future RDF Working Group for potential inclusion at that time. Similarly, we should ensure that the features of RDF are expressed in JSON-LD, to ensure that data can be round-tripped with confidence through different serializations.
+It is noted that the RDF data model is the W3C standard for graph models on the web, and has been for a long time. Consistency and following existing standards are noted above as important ... as is usability and general adoption by developers that are unaware of RDF at all. JSON-LD should be able to serialize all of the RDF data model (enabling a RDF to JSON-LD to RDF round trip, without loss of data). New features that are not present in the RDF data model would not survive a round trip in the other direction (JSON-LD to RDF to JSON-LD), and thus must be carefully considered as to their value.
 
-**Notes**
+**Notes** 
 
-* Objections: There is a more generic data model in JSON-LD, and we have the flexibility to add to it if we want to as long as we're not breaking backwards compatibility with JSON-LD 1.0. We don't want to box ourselves into a corner that will prevent us from thinking creatively about solutions.
+* We will assess the usage and usability of JSON-LD 1.0 features that are not compatible with RDF, with a view to putting in warnings if their usage is not able to be demonstrated.
+* We will prioritize work on features that prevent JSON-LD from being a complete serialization of the RDF data model.
+

--- a/WorkMode/guiding_principles.md
+++ b/WorkMode/guiding_principles.md
@@ -51,33 +51,33 @@ A simpler solution (to understand, implement and use) is better than a more comp
 
 Simplicity is considered in aggregate for the set of features defined by a specification, not independently.  If the same set of features can be accomplished by a smaller number of more consistent patterns, then that method is (very likely) simpler. Memorizing exceptions is harder than memorizing and applying rules.
 
-**Notes**
 
-* The WG discussed up to this point on 2018-07-06.
+`The WG discussed up to this point on 2018-07-06.`
+<!-- Is there a {: .note} or similar? -->
 
-## Simplicity is determined by end users, not library implementers.
+## Proposed: Simplicity is determined by end users, not library implementers.
 
 Simplicity (or usability) is determined by the target audience (data producers and consumers) based on their experience of understanding and applying the specification via existing implementations, not by the experience of implementers of the specification text directly. If there is a feature that makes it harder for implementations, but easier/better for end users, then that is a worthwhile trade off.
 
-## Provide on-ramps.
+## Proposed: Provide on-ramps.
 
 A solution that can be implemented in incremental stages is better than a
 solution that is all or nothing, as not everyone needs every feature but
 many people need various parts.
 
-## Define success, not failure.
+## Proposed: Define success, not failure.
 
 We should define things in terms of what it means to be conformant, rather
 than what is not conformant.  The fewer constraints we require, the easier
 to have non-breaking changes in the future and the easier it is to have
 experimentation.
 
-## Follow existing standards and best practices, where possible and where they do not conflict with other principles.
+## Proposed: Follow existing standards and best practices, where possible and where they do not conflict with other principles.
 
 Between invention and reuse, pick reuse... unless that reuse would
 demonstrably harm adoption by being more complicated than necessary.
 
-## The underlying data model is RDF.
+## Proposed: The underlying data model is RDF.
 
 If a feature comes up that can't be modeled with RDF as the underlying abstract data model, then we refer the feature to a future RDF Working Group for potential inclusion at that time. Similarly, we should ensure that the features of RDF are expressed in JSON-LD, to ensure that data can be round-tripped with confidence through different serializations.
 

--- a/WorkMode/index.md
+++ b/WorkMode/index.md
@@ -112,6 +112,13 @@ An [HTML interface to the W3C's IRC system](http://irc.w3.org/) is available. Se
 
 Each repository, including the “core” WG repository, has a wiki instance. Members of the Working Groups are encouraged to use those for temporary discussions, documents, etc. Pages on the repository Wikis have no formal status.
 
+## Process
+
+The [Charter](https://www.w3.org/2018/03/jsonld-wg-charter.html) and the [W3C Process Document](//www.w3.org/Consortium/Process/) are the final arbiters of any process question, however the Working Group has adopted some complimentary, additional processes to aid in its productivity.
+
+* Adoption of [guiding technical principles](guiding_principles) towards quickly coming to consensus
+
+
 ## Patent Policy
 
 The WG's Charter defines the [Patent Policy for this group](https://www.w3.org/2017/04/publ-wg-charter/#patentpolicy):


### PR DESCRIPTION

Adding principles to website, per @iherman's suggestion on the call today.

Review requested from people on the call to ensure it captures accurately, and reasonably succinctly, both the original proposals and the results of the discussion. 