### PR TITLE
Manage json-ld namespace documents

### DIFF
--- a/ns/README.md
+++ b/ns/README.md
@@ -1,0 +1,7 @@
+# Updating vocabulary
+
+Vocabulary definitions are managed in vocab.csv. Add or change entries within this file. Regenerate jsonld.ttl, jsonld.jsonld, and index.html as described below.
+
+# Building index.html, shex.jsonld and shex.ttl
+
+All files are based on vocab.csv,. Run `mk_vocab.rb` to build both `shex.html`, `shex.jsonld` and `shex.ttl`.

--- a/ns/install.sh
+++ b/ns/install.sh
@@ -1,0 +1,2 @@
+sudo apt-get install ruby
+sudo gem install erubis

--- a/ns/json-ld.html
+++ b/ns/json-ld.html
@@ -1,0 +1,60 @@
+<!DOCTYPE html>
+<html lang="en">
+  <head>
+    <meta charset="utf-8" />
+    <title>The JSON-LD Vocabulary</title>
+    <base href="http://www.w3.org/ns/json-ld" typeof="owl:Ontology" />
+    <link href="http://www.w3.org/StyleSheets/TR/W3C-ED" rel="stylesheet">
+    <style>
+      body {
+        background-image: none;
+      }
+    </style>
+  </head>
+  <body>
+    <p><a href="http://www.w3.org/"><img src="http://www.w3.org/Icons/w3c_home" alt="W3C" height="48" width="72"></a></p>
+    <h1 property="rdfs:label">The JSON-LD Vocabulary</h1>
+    <p property="rdfs:comment">This is a vocabulary document and is used to achieve certain features of the JSON-LD language.</p>
+    <h2>Vocabulary Terms</h2>
+    <p>The vocabulary terms below constitute the complete JSON-LD vocabulary.</p>
+    <div resource="#context" typeof="rdf:Property">
+      <h3 property="rdfs:label">JSON-LD context</h3>
+      <p><code>http://www.w3.org/ns/json-ld#context</code></p>
+      <p property="rdfs:comment">This link relation is used to reference a JSON-LD context from a JSON document so that it can be interpreted as JSON-LD.</p>
+      <p>You can read more about this feature in the <a property="rdfs:seeAlso" href="http://www.w3.org/TR/json-ld11/#interpreting-json-as-json-ld">JSON-LD Syntax specification</a>.</p>
+      <link property="rdfs:isDefinedBy" href="http://www.w3.org/ns/json-ld" />
+    </div>
+    <div resource="#expanded">
+      <h3 property="rdfs:label">Expanded JSON-LD document form</h3>
+      <p><code>http://www.w3.org/ns/json-ld#expanded</code></p>
+      <p property="rdfs:comment">This profile URI is used to request or specify expanded JSON-LD document form.</p>
+      <p>You can read more about this feature in the <a property="rdfs:seeAlso" href="https://www.w3.org/TR/json-ld11/#iana-considerations">JSON-LD Syntax specification</a>.</p>
+      <link property="rdfs:isDefinedBy" href="http://www.w3.org/ns/json-ld" />
+    </div>
+    <div resource="#compacted">
+      <h3 property="rdfs:label">Compacted JSON-LD document form</h3>
+      <p><code>http://www.w3.org/ns/json-ld#compacted</code></p>
+      <p property="rdfs:comment">This profile URI is used to request or specify compacted JSON-LD document form.</p>
+      <p>You can read more about this feature in the <a property="rdfs:seeAlso" href="https://www.w3.org/TR/json-ld11/#iana-considerations">JSON-LD Syntax specification</a>.</p>
+      <link property="rdfs:isDefinedBy" href="http://www.w3.org/ns/json-ld" />
+    </div>
+    <div resource="#flattened">
+      <h3 property="rdfs:label">Flattened JSON-LD document form</h3>
+      <p><code>http://www.w3.org/ns/json-ld#flattened</code></p>
+      <p property="rdfs:comment">This profile URI is used to request or specify flattened JSON-LD document form.</p>
+      <p>You can read more about this feature in the <a property="rdfs:seeAlso" href="https://www.w3.org/TR/json-ld11/#iana-considerations">JSON-LD Syntax specification</a>.</p>
+      <link property="rdfs:isDefinedBy" href="http://www.w3.org/ns/json-ld" />
+    </div>
+    <p>&nbsp;</p>
+    <hr>
+    <p class="copyright">
+      <a href="http://www.w3.org/Consortium/Legal/ipr-notice#Copyright">Copyright</a> &copy; 2013
+      <a href="http://www.w3.org/"><abbr title="World Wide Web Consortium">W3C</abbr></a><sup>&reg;</sup>
+      (<a href="http://www.csail.mit.edu/"><abbr title="Massachusetts Institute of Technology">MIT</abbr></a>,
+      <a href="http://www.ercim.eu/"><abbr title="European Research Consortium for Informatics and Mathematics">ERCIM</abbr></a>,
+      <a href="http://www.keio.ac.jp/">Keio</a>, <a href="http://ev.buaa.edu.cn/">Beihang</a>), All Rights Reserved.
+      W3C <a href="http://www.w3.org/Consortium/Legal/ipr-notice#Legal_Disclaimer">liability</a>,
+      <a href="http://www.w3.org/Consortium/Legal/ipr-notice#W3C_Trademarks">trademark</a> and
+      <a href="http://www.w3.org/Consortium/Legal/copyright-documents">document use</a> rules apply.</p>
+  </body>
+</html>

--- a/ns/json-ld.html
+++ b/ns/json-ld.html
@@ -34,7 +34,7 @@
     <dl>
       <dt>Published:</dt><dd><time property="dc:date">2018-11-12</time></dd>
       <dt>Version Info:</dt>
-      <dd><a href="https://github.com/w3c/json-ld-wg/commit/uncommitted" property="owl:versionInfo">https://github.com/w3c/json-ld-wg/commit/uncommitted</a></dd>
+      <dd><a href="https://github.com/w3c/json-ld-wg/commit/9ef51f288acf3bb2a96f197bc410e455546c8c7a" property="owl:versionInfo">https://github.com/w3c/json-ld-wg/commit/9ef51f288acf3bb2a96f197bc410e455546c8c7a</a></dd>
       <dt>See Also:</dt>
         <dd><a href="http://www.w3.org/TR/json-ld11" property="rdfs:seeAlso">http://www.w3.org/TR/json-ld11</a></dd>
     </dl>
@@ -55,23 +55,29 @@
       <h2>Property Definitions</h2>
       <p>The following are property definitions in the <code>jsonld</code> namespace:</p>
       <table class="rdfs-definition">
-        <tr id="compacted">
-          <td class="bold">compacted</td>
-          <td resource="jsonld:compacted" typeof="rdf:Property">
-            <em property="rdfs:label">compacted</em>
-            <span class="permalink"><a href="#compacted" aria-label="Permalink for compacted" title="Permalink for compacted"><span>§</span></a></span>
-            <p property="rdfs:comment">This profile URI is used to request or specify expanded JSON-LD document form.</p>
-            <p>You can read more about this feature in the <a property="rdfs:seeAlso" href="">JSON-LD Syntax specification</a>.</p>
-            
-            <span property="rdfs:isDefinedBy" resource="jsonld:"></span>
-          </td>
-        </tr>
         <tr id="context">
           <td class="bold">context</td>
           <td resource="jsonld:context" typeof="rdf:Property">
             <em property="rdfs:label">context</em>
             <span class="permalink"><a href="#context" aria-label="Permalink for context" title="Permalink for context"><span>§</span></a></span>
-            <p property="rdfs:comment">This is a vocabulary document and is used to achieve certain features of the JSON-LD language.</p>
+            <p property="rdfs:comment">This link relation is used to reference a JSON-LD context from a JSON document so that it can be interpreted as JSON-LD.</p>
+            <p>You can read more about this feature in the <a property="rdfs:seeAlso" href="">JSON-LD Syntax specification</a>.</p>
+            
+            <span property="rdfs:isDefinedBy" resource="jsonld:"></span>
+          </td>
+        </tr>
+      </table>
+    </section>
+    <section>
+      <h2>Instance Definitions</h2>
+      <p>The following are instance definitions in the <code>jsonld</code> namespace:</p>
+      <table class="rdfs-definition">
+        <tr id="compacted">
+          <td class="bold">compacted</td>
+          <td resource="jsonld:compacted" typeof="owl:NamedIndividual">
+            <em property="rdfs:label">compacted</em>
+            <span class="permalink"><a href="#compacted" aria-label="Permalink for compacted" title="Permalink for compacted"><span>§</span></a></span>
+            <p property="rdfs:comment">This profile IRI is used to request or specify compacted JSON-LD document form.</p>
             <p>You can read more about this feature in the <a property="rdfs:seeAlso" href="">JSON-LD Syntax specification</a>.</p>
             
             <span property="rdfs:isDefinedBy" resource="jsonld:"></span>
@@ -79,10 +85,10 @@
         </tr>
         <tr id="expanded">
           <td class="bold">expanded</td>
-          <td resource="jsonld:expanded" typeof="rdf:Property">
+          <td resource="jsonld:expanded" typeof="owl:NamedIndividual">
             <em property="rdfs:label">expanded</em>
             <span class="permalink"><a href="#expanded" aria-label="Permalink for expanded" title="Permalink for expanded"><span>§</span></a></span>
-            <p property="rdfs:comment">This link relation is used to reference a JSON-LD context from a JSON document so that it can be interpreted as JSON-LD.</p>
+            <p property="rdfs:comment">This profile URI is used to request or specify expanded JSON-LD document form.</p>
             <p>You can read more about this feature in the <a property="rdfs:seeAlso" href="">JSON-LD Syntax specification</a>.</p>
             
             <span property="rdfs:isDefinedBy" resource="jsonld:"></span>
@@ -90,7 +96,7 @@
         </tr>
         <tr id="flattened">
           <td class="bold">flattened</td>
-          <td resource="jsonld:flattened" typeof="rdf:Property">
+          <td resource="jsonld:flattened" typeof="owl:NamedIndividual">
             <em property="rdfs:label">flattened</em>
             <span class="permalink"><a href="#flattened" aria-label="Permalink for flattened" title="Permalink for flattened"><span>§</span></a></span>
             <p property="rdfs:comment">This profile URI is used to request or specify flattened JSON-LD document form.</p>

--- a/ns/json-ld.html
+++ b/ns/json-ld.html
@@ -1,60 +1,126 @@
-<!DOCTYPE html>
 <html lang="en">
   <head>
-    <meta charset="utf-8" />
+    <meta charset='utf-8'/>
     <title>The JSON-LD Vocabulary</title>
-    <base href="http://www.w3.org/ns/json-ld" typeof="owl:Ontology" />
+    <base href="http://www.w3.org/ns/json-ld#" />
+    <script class="remove" src="https://www.w3.org/Tools/respec/respec-w3c-common"></script>
     <link href="http://www.w3.org/StyleSheets/TR/W3C-ED" rel="stylesheet">
-    <style>
-      body {
-        background-image: none;
+    <style type="text/css">
+      dl.terms dt {
+        float: left;
+        clear: left;
+        width: 17vw;
       }
+      dl.terms dd:after {
+          content: '';
+          display: block;
+          clear: both;
+          margin-bottom: 5px;
+      }
+      table.rdfs-definition td {vertical-align: top;}
+      .bold {font-weight: bold;}
     </style>
   </head>
-  <body>
-    <p><a href="http://www.w3.org/"><img src="http://www.w3.org/Icons/w3c_home" alt="W3C" height="48" width="72"></a></p>
+  <body resource="http://www.w3.org/ns/json-ld#" typeof="owl:Ontology" prefix="jsonld: http://www.w3.org/ns/json-ld#">
     <h1 property="rdfs:label">The JSON-LD Vocabulary</h1>
+    <p><a href="http://www.w3.org/"><img src="http://www.w3.org/Icons/w3c_home" alt="W3C" height="48" width="72"></a></p>
     <p property="rdfs:comment">This is a vocabulary document and is used to achieve certain features of the JSON-LD language.</p>
-    <h2>Vocabulary Terms</h2>
-    <p>The vocabulary terms below constitute the complete JSON-LD vocabulary.</p>
-    <div resource="#context" typeof="rdf:Property">
-      <h3 property="rdfs:label">JSON-LD context</h3>
-      <p><code>http://www.w3.org/ns/json-ld#context</code></p>
-      <p property="rdfs:comment">This link relation is used to reference a JSON-LD context from a JSON document so that it can be interpreted as JSON-LD.</p>
-      <p>You can read more about this feature in the <a property="rdfs:seeAlso" href="http://www.w3.org/TR/json-ld11/#interpreting-json-as-json-ld">JSON-LD Syntax specification</a>.</p>
-      <link property="rdfs:isDefinedBy" href="http://www.w3.org/ns/json-ld" />
-    </div>
-    <div resource="#expanded">
-      <h3 property="rdfs:label">Expanded JSON-LD document form</h3>
-      <p><code>http://www.w3.org/ns/json-ld#expanded</code></p>
-      <p property="rdfs:comment">This profile URI is used to request or specify expanded JSON-LD document form.</p>
-      <p>You can read more about this feature in the <a property="rdfs:seeAlso" href="https://www.w3.org/TR/json-ld11/#iana-considerations">JSON-LD Syntax specification</a>.</p>
-      <link property="rdfs:isDefinedBy" href="http://www.w3.org/ns/json-ld" />
-    </div>
-    <div resource="#compacted">
-      <h3 property="rdfs:label">Compacted JSON-LD document form</h3>
-      <p><code>http://www.w3.org/ns/json-ld#compacted</code></p>
-      <p property="rdfs:comment">This profile URI is used to request or specify compacted JSON-LD document form.</p>
-      <p>You can read more about this feature in the <a property="rdfs:seeAlso" href="https://www.w3.org/TR/json-ld11/#iana-considerations">JSON-LD Syntax specification</a>.</p>
-      <link property="rdfs:isDefinedBy" href="http://www.w3.org/ns/json-ld" />
-    </div>
-    <div resource="#flattened">
-      <h3 property="rdfs:label">Flattened JSON-LD document form</h3>
-      <p><code>http://www.w3.org/ns/json-ld#flattened</code></p>
-      <p property="rdfs:comment">This profile URI is used to request or specify flattened JSON-LD document form.</p>
-      <p>You can read more about this feature in the <a property="rdfs:seeAlso" href="https://www.w3.org/TR/json-ld11/#iana-considerations">JSON-LD Syntax specification</a>.</p>
-      <link property="rdfs:isDefinedBy" href="http://www.w3.org/ns/json-ld" />
-    </div>
-    <p>&nbsp;</p>
-    <hr>
-    <p class="copyright">
-      <a href="http://www.w3.org/Consortium/Legal/ipr-notice#Copyright">Copyright</a> &copy; 2013
-      <a href="http://www.w3.org/"><abbr title="World Wide Web Consortium">W3C</abbr></a><sup>&reg;</sup>
-      (<a href="http://www.csail.mit.edu/"><abbr title="Massachusetts Institute of Technology">MIT</abbr></a>,
-      <a href="http://www.ercim.eu/"><abbr title="European Research Consortium for Informatics and Mathematics">ERCIM</abbr></a>,
-      <a href="http://www.keio.ac.jp/">Keio</a>, <a href="http://ev.buaa.edu.cn/">Beihang</a>), All Rights Reserved.
-      W3C <a href="http://www.w3.org/Consortium/Legal/ipr-notice#Legal_Disclaimer">liability</a>,
-      <a href="http://www.w3.org/Consortium/Legal/ipr-notice#W3C_Trademarks">trademark</a> and
-      <a href="http://www.w3.org/Consortium/Legal/copyright-documents">document use</a> rules apply.</p>
+    <p>Alternate versions of the vocabulary definition exist in
+      <a rel="alternate" href="jsonld.ttl">Turtle</a> and
+      <a rel="alternate" href="jsonld.jsonld">JSON-LD</a>,
+      which also includes the <code>@context</code> required for metadata descriptions.
+      <!--These versions may also be retrieved from <code>FIXME</code> using an appropiate HTTP <em>Accept</em> header.-->
+    </p>
+    <dl>
+      <dt>Published:</dt><dd><time property="dc:date">2018-11-12</time></dd>
+      <dt>Version Info:</dt>
+      <dd><a href="https://github.com/w3c/json-ld-wg/commit/uncommitted" property="owl:versionInfo">https://github.com/w3c/json-ld-wg/commit/uncommitted</a></dd>
+      <dt>See Also:</dt>
+        <dd><a href="http://www.w3.org/TR/json-ld11" property="rdfs:seeAlso">http://www.w3.org/TR/json-ld11</a></dd>
+    </dl>
+    <section>
+      <h2>Prefix Definitions</h2>
+      <dl class="terms">
+        <dt>jsonld</dt>
+        <dd>http://www.w3.org/ns/json-ld#</dd>
+        <dt>rdf</dt>
+        <dd>http://www.w3.org/1999/02/22-rdf-syntax-ns#</dd>
+        <dt>rdfs</dt>
+        <dd>http://www.w3.org/2000/01/rdf-schema#</dd>
+        <dt>xsd</dt>
+        <dd>http://www.w3.org/2001/XMLSchema#</dd>
+      </dl>
+    </section>
+    <section>
+      <h2>Property Definitions</h2>
+      <p>The following are property definitions in the <code>jsonld</code> namespace:</p>
+      <table class="rdfs-definition">
+        <tr id="compacted">
+          <td class="bold">compacted</td>
+          <td resource="jsonld:compacted" typeof="rdf:Property">
+            <em property="rdfs:label">compacted</em>
+            <span class="permalink"><a href="#compacted" aria-label="Permalink for compacted" title="Permalink for compacted"><span>§</span></a></span>
+            <p property="rdfs:comment">This profile URI is used to request or specify expanded JSON-LD document form.</p>
+            <p>You can read more about this feature in the <a property="rdfs:seeAlso" href="">JSON-LD Syntax specification</a>.</p>
+            
+            <span property="rdfs:isDefinedBy" resource="jsonld:"></span>
+          </td>
+        </tr>
+        <tr id="context">
+          <td class="bold">context</td>
+          <td resource="jsonld:context" typeof="rdf:Property">
+            <em property="rdfs:label">context</em>
+            <span class="permalink"><a href="#context" aria-label="Permalink for context" title="Permalink for context"><span>§</span></a></span>
+            <p property="rdfs:comment">This is a vocabulary document and is used to achieve certain features of the JSON-LD language.</p>
+            <p>You can read more about this feature in the <a property="rdfs:seeAlso" href="">JSON-LD Syntax specification</a>.</p>
+            
+            <span property="rdfs:isDefinedBy" resource="jsonld:"></span>
+          </td>
+        </tr>
+        <tr id="expanded">
+          <td class="bold">expanded</td>
+          <td resource="jsonld:expanded" typeof="rdf:Property">
+            <em property="rdfs:label">expanded</em>
+            <span class="permalink"><a href="#expanded" aria-label="Permalink for expanded" title="Permalink for expanded"><span>§</span></a></span>
+            <p property="rdfs:comment">This link relation is used to reference a JSON-LD context from a JSON document so that it can be interpreted as JSON-LD.</p>
+            <p>You can read more about this feature in the <a property="rdfs:seeAlso" href="">JSON-LD Syntax specification</a>.</p>
+            
+            <span property="rdfs:isDefinedBy" resource="jsonld:"></span>
+          </td>
+        </tr>
+        <tr id="flattened">
+          <td class="bold">flattened</td>
+          <td resource="jsonld:flattened" typeof="rdf:Property">
+            <em property="rdfs:label">flattened</em>
+            <span class="permalink"><a href="#flattened" aria-label="Permalink for flattened" title="Permalink for flattened"><span>§</span></a></span>
+            <p property="rdfs:comment">This profile URI is used to request or specify flattened JSON-LD document form.</p>
+            <p>You can read more about this feature in the <a property="rdfs:seeAlso" href="">JSON-LD Syntax specification</a>.</p>
+            
+            <span property="rdfs:isDefinedBy" resource="jsonld:"></span>
+          </td>
+        </tr>
+      </table>
+    </section>
+    <section>
+      <h2>Term Definitions</h2>
+      <dl class="terms">
+        <dt>compacted</dt>
+        <dd>
+            jsonld:compacted
+        </dd>
+        <dt>context</dt>
+        <dd>
+            jsonld:context
+        </dd>
+        <dt>expanded</dt>
+        <dd>
+            jsonld:expanded
+        </dd>
+        <dt>flattened</dt>
+        <dd>
+            jsonld:flattened
+        </dd>
+      </dl>
+    </section>
   </body>
 </html>

--- a/ns/json-ld.jsonld
+++ b/ns/json-ld.jsonld
@@ -1,0 +1,47 @@
+{
+  "@context": {
+    "rdfs": "http://www.w3.org/2000/01/rdf-schema#",
+    "label": "rdfs:label",
+    "description": "rdfs:comment",
+    "seeAlso": { "@id": "rdfs:seeAlso", "@type": "@id" },
+    "isDefinedBy": { "@id": "rdfs:isDefinedBy", "@type": "@id" },
+    "@language": "en"
+  },
+  "@graph": [
+    {
+      "@id": "http://www.w3.org/ns/json-ld",
+      "@type": "http://www.w3.org/2002/07/owl#Ontology",
+      "label": "The JSON-LD Vocabulary",
+      "description": "This is a vocabulary document and is used to achieve certain features of the JSON-LD language."
+    },
+    {
+      "@id": "http://www.w3.org/ns/json-ld#context",
+      "@type": "http://www.w3.org/1999/02/22-rdf-syntax-ns#Property",
+      "label": "JSON-LD context",
+      "description": "This link relation is used to reference a JSON-LD context from a JSON document so that it can be interpreted as JSON-LD.",
+      "seeAlso": "http://www.w3.org/TR/json-ld11/#interpreting-json-as-json-ld",
+      "isDefinedBy": "http://www.w3.org/ns/json-ld"
+    },
+    {
+      "@id": "http://www.w3.org/ns/json-ld#expanded",
+      "label": "Expanded JSON-LD document form",
+      "description": "This profile URI is used to request or specify expanded JSON-LD document form.",
+      "seeAlso": "https://www.w3.org/TR/json-ld11/#iana-considerations",
+      "isDefinedBy": "http://www.w3.org/ns/json-ld"
+    },
+    {
+      "@id": "http://www.w3.org/ns/json-ld#compacted",
+      "label": "Compacted JSON-LD document form",
+      "description": "This profile URI is used to request or specify compacted JSON-LD document form.",
+      "seeAlso": "https://www.w3.org/TR/json-ld11/#iana-considerations",
+      "isDefinedBy": "http://www.w3.org/ns/json-ld"
+    },
+    {
+      "@id": "http://www.w3.org/ns/json-ld#flattened",
+      "label": "Flattened JSON-LD document form",
+      "description": "This profile URI is used to request or specify flattened JSON-LD document form.",
+      "seeAlso": "https://www.w3.org/TR/json-ld11/#iana-considerations",
+      "isDefinedBy": "http://www.w3.org/ns/json-ld"
+    }
+  ]
+}

--- a/ns/json-ld.jsonld
+++ b/ns/json-ld.jsonld
@@ -1,47 +1,158 @@
 {
   "@context": {
+    "jsonld": "http://www.w3.org/ns/json-ld#",
+    "rdf": "http://www.w3.org/1999/02/22-rdf-syntax-ns#",
     "rdfs": "http://www.w3.org/2000/01/rdf-schema#",
-    "label": "rdfs:label",
-    "description": "rdfs:comment",
-    "seeAlso": { "@id": "rdfs:seeAlso", "@type": "@id" },
-    "isDefinedBy": { "@id": "rdfs:isDefinedBy", "@type": "@id" },
-    "@language": "en"
-  },
-  "@graph": [
-    {
-      "@id": "http://www.w3.org/ns/json-ld",
-      "@type": "http://www.w3.org/2002/07/owl#Ontology",
-      "label": "The JSON-LD Vocabulary",
-      "description": "This is a vocabulary document and is used to achieve certain features of the JSON-LD language."
+    "xsd": "http://www.w3.org/2001/XMLSchema#",
+    "compacted": {
+      "@id": "jsonld:compacted"
     },
-    {
-      "@id": "http://www.w3.org/ns/json-ld#context",
-      "@type": "http://www.w3.org/1999/02/22-rdf-syntax-ns#Property",
-      "label": "JSON-LD context",
-      "description": "This link relation is used to reference a JSON-LD context from a JSON document so that it can be interpreted as JSON-LD.",
-      "seeAlso": "http://www.w3.org/TR/json-ld11/#interpreting-json-as-json-ld",
-      "isDefinedBy": "http://www.w3.org/ns/json-ld"
+    "context": {
+      "@id": "jsonld:context"
     },
-    {
-      "@id": "http://www.w3.org/ns/json-ld#expanded",
-      "label": "Expanded JSON-LD document form",
-      "description": "This profile URI is used to request or specify expanded JSON-LD document form.",
-      "seeAlso": "https://www.w3.org/TR/json-ld11/#iana-considerations",
-      "isDefinedBy": "http://www.w3.org/ns/json-ld"
+    "expanded": {
+      "@id": "jsonld:expanded"
     },
-    {
-      "@id": "http://www.w3.org/ns/json-ld#compacted",
-      "label": "Compacted JSON-LD document form",
-      "description": "This profile URI is used to request or specify compacted JSON-LD document form.",
-      "seeAlso": "https://www.w3.org/TR/json-ld11/#iana-considerations",
-      "isDefinedBy": "http://www.w3.org/ns/json-ld"
-    },
-    {
-      "@id": "http://www.w3.org/ns/json-ld#flattened",
-      "label": "Flattened JSON-LD document form",
-      "description": "This profile URI is used to request or specify flattened JSON-LD document form.",
-      "seeAlso": "https://www.w3.org/TR/json-ld11/#iana-considerations",
-      "isDefinedBy": "http://www.w3.org/ns/json-ld"
+    "flattened": {
+      "@id": "jsonld:flattened"
     }
-  ]
+  },
+  "@graph": {
+    "@context": {
+      "id": "@id",
+      "type": "@type",
+      "dc:title": {
+        "@container": "@language"
+      },
+      "dc:description": {
+        "@container": "@language"
+      },
+      "dc:date": {
+        "@type": "xsd:date"
+      },
+      "rdfs:comment": {
+        "@container": "@language"
+      },
+      "rdfs:domain": {
+        "@type": "@id"
+      },
+      "rdfs:label": {
+        "@container": "@language"
+      },
+      "rdfs:range": {
+        "@type": "@id"
+      },
+      "rdfs:seeAlso": {
+        "@type": "@id"
+      },
+      "rdfs:subClassOf": {
+        "@type": "@id"
+      },
+      "rdfs:subPropertyOf": {
+        "@type": "@id"
+      },
+      "owl:equivalentClass": {
+        "@type": "@vocab"
+      },
+      "owl:equivalentProperty": {
+        "@type": "@vocab"
+      },
+      "owl:oneOf": {
+        "@container": "@list",
+        "@type": "@vocab"
+      },
+      "owl:imports": {
+        "@type": "@id"
+      },
+      "owl:versionInfo": {
+        "@type": "@id"
+      },
+      "owl:inverseOf": {
+        "@type": "@vocab"
+      },
+      "owl:unionOf": {
+        "@type": "@vocab",
+        "@container": "@list"
+      },
+      "rdfs_classes": {
+        "@reverse": "rdfs:isDefinedBy",
+        "@type": "@id"
+      },
+      "rdfs_properties": {
+        "@reverse": "rdfs:isDefinedBy",
+        "@type": "@id"
+      },
+      "rdfs_datatypes": {
+        "@reverse": "rdfs:isDefinedBy",
+        "@type": "@id"
+      },
+      "rdfs_instances": {
+        "@reverse": "rdfs:isDefinedBy",
+        "@type": "@id"
+      }
+    },
+    "@id": "http://www.w3.org/ns/json-ld#",
+    "@type": "owl:Ontology",
+    "dc": "http://purl.org/dc/terms/",
+    "owl": "http://www.w3.org/2002/07/owl#",
+    "rdf": "http://www.w3.org/1999/02/22-rdf-syntax-ns#",
+    "rdfs": "http://www.w3.org/2000/01/rdf-schema#",
+    "dc:title": {
+      "en": "The JSON-LD Vocabulary"
+    },
+    "dc:description": {
+      "en": "This is a vocabulary document and is used to achieve certain features of the JSON-LD language."
+    },
+    "dc:date": "2018-11-12",
+    "owl:versionInfo": "https://github.com/w3c/json-ld-wg/commit/uncommitted",
+    "rdfs:seeAlso": [
+      "http://www.w3.org/TR/json-ld11"
+    ],
+    "rdfs_properties": [
+      {
+        "@id": "jsonld:compacted",
+        "@type": "rdf:Property",
+        "rdfs:label": {
+          "en": "compacted"
+        },
+        "rdfs:comment": {
+          "en": "This profile URI is used to request or specify expanded JSON-LD document form."
+        },
+        "rdfs:seeAlso": "https://www.w3.org/TR/json-ld11/#iana-considerations"
+      },
+      {
+        "@id": "jsonld:context",
+        "@type": "rdf:Property",
+        "rdfs:label": {
+          "en": "context"
+        },
+        "rdfs:comment": {
+          "en": "This is a vocabulary document and is used to achieve certain features of the JSON-LD language."
+        },
+        "rdfs:seeAlso": "http://www.w3.org/TR/json-ld11/#interpreting-json-as-json-ld"
+      },
+      {
+        "@id": "jsonld:expanded",
+        "@type": "rdf:Property",
+        "rdfs:label": {
+          "en": "expanded"
+        },
+        "rdfs:comment": {
+          "en": "This link relation is used to reference a JSON-LD context from a JSON document so that it can be interpreted as JSON-LD."
+        },
+        "rdfs:seeAlso": "https://www.w3.org/TR/json-ld11/#iana-considerations"
+      },
+      {
+        "@id": "jsonld:flattened",
+        "@type": "rdf:Property",
+        "rdfs:label": {
+          "en": "flattened"
+        },
+        "rdfs:comment": {
+          "en": "This profile URI is used to request or specify flattened JSON-LD document form."
+        },
+        "rdfs:seeAlso": "https://www.w3.org/TR/json-ld11/#iana-considerations"
+      }
+    ]
+  }
 }

--- a/ns/json-ld.jsonld
+++ b/ns/json-ld.jsonld
@@ -4,11 +4,11 @@
     "rdf": "http://www.w3.org/1999/02/22-rdf-syntax-ns#",
     "rdfs": "http://www.w3.org/2000/01/rdf-schema#",
     "xsd": "http://www.w3.org/2001/XMLSchema#",
-    "compacted": {
-      "@id": "jsonld:compacted"
-    },
     "context": {
       "@id": "jsonld:context"
+    },
+    "compacted": {
+      "@id": "jsonld:compacted"
     },
     "expanded": {
       "@id": "jsonld:expanded"
@@ -104,22 +104,11 @@
       "en": "This is a vocabulary document and is used to achieve certain features of the JSON-LD language."
     },
     "dc:date": "2018-11-12",
-    "owl:versionInfo": "https://github.com/w3c/json-ld-wg/commit/uncommitted",
+    "owl:versionInfo": "https://github.com/w3c/json-ld-wg/commit/9ef51f288acf3bb2a96f197bc410e455546c8c7a",
     "rdfs:seeAlso": [
       "http://www.w3.org/TR/json-ld11"
     ],
     "rdfs_properties": [
-      {
-        "@id": "jsonld:compacted",
-        "@type": "rdf:Property",
-        "rdfs:label": {
-          "en": "compacted"
-        },
-        "rdfs:comment": {
-          "en": "This profile URI is used to request or specify expanded JSON-LD document form."
-        },
-        "rdfs:seeAlso": "https://www.w3.org/TR/json-ld11/#iana-considerations"
-      },
       {
         "@id": "jsonld:context",
         "@type": "rdf:Property",
@@ -127,24 +116,37 @@
           "en": "context"
         },
         "rdfs:comment": {
-          "en": "This is a vocabulary document and is used to achieve certain features of the JSON-LD language."
+          "en": "This link relation is used to reference a JSON-LD context from a JSON document so that it can be interpreted as JSON-LD."
         },
         "rdfs:seeAlso": "http://www.w3.org/TR/json-ld11/#interpreting-json-as-json-ld"
+      }
+    ],
+    "rdfs_instances": [
+      {
+        "@id": "jsonld:compacted",
+        "@type": "owl:NamedIndividual",
+        "rdfs:label": {
+          "en": "compacted"
+        },
+        "rdfs:comment": {
+          "en": "This profile IRI is used to request or specify compacted JSON-LD document form."
+        },
+        "rdfs:seeAlso": "https://www.w3.org/TR/json-ld11/#iana-considerations"
       },
       {
         "@id": "jsonld:expanded",
-        "@type": "rdf:Property",
+        "@type": "owl:NamedIndividual",
         "rdfs:label": {
           "en": "expanded"
         },
         "rdfs:comment": {
-          "en": "This link relation is used to reference a JSON-LD context from a JSON document so that it can be interpreted as JSON-LD."
+          "en": "This profile URI is used to request or specify expanded JSON-LD document form."
         },
         "rdfs:seeAlso": "https://www.w3.org/TR/json-ld11/#iana-considerations"
       },
       {
         "@id": "jsonld:flattened",
-        "@type": "rdf:Property",
+        "@type": "owl:NamedIndividual",
         "rdfs:label": {
           "en": "flattened"
         },

--- a/ns/json-ld.ttl
+++ b/ns/json-ld.ttl
@@ -11,29 +11,28 @@ jsonld: a owl:Ontology;
   dc:description """This is a vocabulary document and is used to achieve certain features of the JSON-LD language."""@en;
   dc:date "2018-11-12"^^xsd:date;
   dc:imports ;
-  owl:versionInfo <https://github.com/w3c/json-ld-wg/commit/uncommitted>;
+  owl:versionInfo <https://github.com/w3c/json-ld-wg/commit/9ef51f288acf3bb2a96f197bc410e455546c8c7a>;
   rdfs:seeAlso <http://www.w3.org/TR/json-ld11>;
   .
 
 
 # Property definitions
-jsonld:compacted a rdf:Property;
-  rdfs:label "compacted"@en;
-  rdfs:comment """This profile URI is used to request or specify expanded JSON-LD document form."""@en;
-  rdfs:seeAlso <https://www.w3.org/TR/json-ld11/#iana-considerations>;
-  rdfs:isDefinedBy jsonld: .
 jsonld:context a rdf:Property;
   rdfs:label "context"@en;
-  rdfs:comment """This is a vocabulary document and is used to achieve certain features of the JSON-LD language."""@en;
+  rdfs:comment """This link relation is used to reference a JSON-LD context from a JSON document so that it can be interpreted as JSON-LD."""@en;
   rdfs:seeAlso <http://www.w3.org/TR/json-ld11/#interpreting-json-as-json-ld>;
   rdfs:isDefinedBy jsonld: .
-jsonld:expanded a rdf:Property;
-  rdfs:label "expanded"@en;
-  rdfs:comment """This link relation is used to reference a JSON-LD context from a JSON document so that it can be interpreted as JSON-LD."""@en;
-  rdfs:seeAlso <https://www.w3.org/TR/json-ld11/#iana-considerations>;
+
+# Instance definitions
+jsonld:compacted a owl:NamedIndividual;
+  rdfs:label "compacted"@en;
+  rdfs:comment """This profile IRI is used to request or specify compacted JSON-LD document form."""@en;
   rdfs:isDefinedBy jsonld: .
-jsonld:flattened a rdf:Property;
+jsonld:expanded a owl:NamedIndividual;
+  rdfs:label "expanded"@en;
+  rdfs:comment """This profile URI is used to request or specify expanded JSON-LD document form."""@en;
+  rdfs:isDefinedBy jsonld: .
+jsonld:flattened a owl:NamedIndividual;
   rdfs:label "flattened"@en;
   rdfs:comment """This profile URI is used to request or specify flattened JSON-LD document form."""@en;
-  rdfs:seeAlso <https://www.w3.org/TR/json-ld11/#iana-considerations>;
   rdfs:isDefinedBy jsonld: .

--- a/ns/json-ld.ttl
+++ b/ns/json-ld.ttl
@@ -1,0 +1,39 @@
+@prefix dc: <http;//purl.org/dc/terms/> .
+@prefix owl: <http://www.w3.org/2002/07/owl#> .
+@prefix rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#> .
+@prefix rdfs: <http://www.w3.org/2000/01/rdf-schema#> .
+@prefix jsonld: <http://www.w3.org/ns/json-ld#> .
+@prefix xsd: <http://www.w3.org/2001/XMLSchema#> .
+
+# JSON-LD Ontology definition
+jsonld: a owl:Ontology;
+  dc:title "The JSON-LD Vocabulary"@en;
+  dc:description """This is a vocabulary document and is used to achieve certain features of the JSON-LD language."""@en;
+  dc:date "2018-11-12"^^xsd:date;
+  dc:imports ;
+  owl:versionInfo <https://github.com/w3c/json-ld-wg/commit/uncommitted>;
+  rdfs:seeAlso <http://www.w3.org/TR/json-ld11>;
+  .
+
+
+# Property definitions
+jsonld:compacted a rdf:Property;
+  rdfs:label "compacted"@en;
+  rdfs:comment """This profile URI is used to request or specify expanded JSON-LD document form."""@en;
+  rdfs:seeAlso <https://www.w3.org/TR/json-ld11/#iana-considerations>;
+  rdfs:isDefinedBy jsonld: .
+jsonld:context a rdf:Property;
+  rdfs:label "context"@en;
+  rdfs:comment """This is a vocabulary document and is used to achieve certain features of the JSON-LD language."""@en;
+  rdfs:seeAlso <http://www.w3.org/TR/json-ld11/#interpreting-json-as-json-ld>;
+  rdfs:isDefinedBy jsonld: .
+jsonld:expanded a rdf:Property;
+  rdfs:label "expanded"@en;
+  rdfs:comment """This link relation is used to reference a JSON-LD context from a JSON document so that it can be interpreted as JSON-LD."""@en;
+  rdfs:seeAlso <https://www.w3.org/TR/json-ld11/#iana-considerations>;
+  rdfs:isDefinedBy jsonld: .
+jsonld:flattened a rdf:Property;
+  rdfs:label "flattened"@en;
+  rdfs:comment """This profile URI is used to request or specify flattened JSON-LD document form."""@en;
+  rdfs:seeAlso <https://www.w3.org/TR/json-ld11/#iana-considerations>;
+  rdfs:isDefinedBy jsonld: .

--- a/ns/mk_vocab.rb
+++ b/ns/mk_vocab.rb
@@ -1,0 +1,359 @@
+#! /usr/bin/env ruby
+# Parse vocabulary definition in CSV to generate Context+Vocabulary in JSON-LD or Turtle
+
+require 'getoptlong'
+require 'csv'
+require 'json'
+require 'erubis'
+
+class Vocab
+  JSON_STATE = JSON::State.new(
+    :indent       => "  ",
+    :space        => " ",
+    :space_before => "",
+    :object_nl    => "\n",
+    :array_nl     => "\n"
+  )
+
+  TITLE = "The JSON-LD Vocabulary".freeze
+  DESCRIPTION = %(This is a vocabulary document and is used to achieve certain features of the JSON-LD language.).freeze
+  attr_accessor :prefixes, :terms, :properties, :classes, :instances, :datatypes,
+                :imports, :date, :commit, :seeAlso
+
+  def initialize
+    path = File.expand_path("../vocab.csv", __FILE__)
+    csv = CSV.new(File.open(path))
+    @prefixes, @terms, @properties, @classes, @datatypes, @instances = {}, {}, {}, {}, {}, {}
+    @imports, @seeAlso = [], []
+    git_info = %x{git log -1 #{path}}.split("\n")
+    @commit = "https://github.com/w3c/json-ld-wg/commit/" + (git_info[0] || 'uncommitted').split.last
+    date_line = git_info.detect {|l| l.start_with?("Date:")}
+    @date = Date.parse((date_line || Date.today.to_s).split(":",2).last).strftime("%Y-%m-%d")
+
+    columns = []
+    csv.shift.each_with_index {|c, i| columns[i] = c.to_sym if c}
+
+    csv.sort_by(&:to_s).each do |line|
+      entry = {}
+      # Create entry as object indexed by symbolized column name
+      line.each_with_index {|v, i| entry[columns[i]] = v ? v.gsub("\r", "\n").gsub("\\", "\\\\") : nil}
+
+      case entry[:type]
+      when 'prefix'         then @prefixes[entry[:id]] = entry
+      when 'term'           then @terms[entry[:id]] = entry
+      when 'rdf:Property'   then @properties[entry[:id]] = entry
+      when 'rdfs:Class'     then @classes[entry[:id]] = entry
+      when 'rdfs:Datatype'  then @datatypes[entry[:id]] = entry
+      when 'owl:imports'    then @imports << entry[:subClassOf]
+      when 'rdfs:seeAlso'   then @seeAlso << entry[:subClassOf]
+      else                       @instances[entry[:id]] = entry
+      end
+    end
+
+  end
+
+  def namespaced(term)
+    term.include?(":") ? term : "jsonld:#{term}"
+  end
+
+  def to_jsonld
+    context = {}
+    rdfs_context = ::JSON.parse %({
+      "id": "@id",
+      "type": "@type",
+      "dc:title": {"@container": "@language"},
+      "dc:description": {"@container": "@language"},
+      "dc:date": {"@type": "xsd:date"},
+      "rdfs:comment": {"@container": "@language"},
+      "rdfs:domain": {"@type": "@id"},
+      "rdfs:label": {"@container": "@language"},
+      "rdfs:range": {"@type": "@id"},
+      "rdfs:seeAlso": {"@type": "@id"},
+      "rdfs:subClassOf": {"@type": "@id"},
+      "rdfs:subPropertyOf": {"@type": "@id"},
+      "owl:equivalentClass": {"@type": "@vocab"},
+      "owl:equivalentProperty": {"@type": "@vocab"},
+      "owl:oneOf": {"@container": "@list", "@type": "@vocab"},
+      "owl:imports": {"@type": "@id"},
+      "owl:versionInfo": {"@type": "@id"},
+      "owl:inverseOf": {"@type": "@vocab"},
+      "owl:unionOf": {"@type": "@vocab", "@container": "@list"},
+      "rdfs_classes": {"@reverse": "rdfs:isDefinedBy", "@type": "@id"},
+      "rdfs_properties": {"@reverse": "rdfs:isDefinedBy", "@type": "@id"},
+      "rdfs_datatypes": {"@reverse": "rdfs:isDefinedBy", "@type": "@id"},
+      "rdfs_instances": {"@reverse": "rdfs:isDefinedBy", "@type": "@id"}
+    })
+    rdfs_classes, rdfs_properties, rdfs_datatypes, rdfs_instances = [], [], [], []
+
+    prefixes.each do |id, entry|
+      context[id] = entry[:subClassOf]
+    end
+
+    terms.each do |id, entry|
+      next if entry[:@type] == '@null'
+      context[id] = if [:@container, :@type].any? {|k| entry[k]}
+        {'@id' => entry[:subClassOf]}.
+        merge(entry[:@container] ? {'@container' => entry[:@container]} : {}).
+        merge(entry[:@type] ? {'@type' => entry[:@type]} : {})
+      else
+        entry[:subClassOf]
+      end
+    end
+
+    classes.each do |id, entry|
+      term = entry[:term] || id
+      context[term] = namespaced(id) unless entry[:@type] == '@null'
+
+      # Class definition
+      node = {
+        '@id' => namespaced(id),
+        '@type' => 'rdfs:Class',
+        'rdfs:label' => {"en" => entry[:label].to_s},
+        'rdfs:comment' => {"en" => entry[:comment].to_s},
+      }
+      node['rdfs:subClassOf'] = namespaced(entry[:subClassOf]) if entry[:subClassOf]
+      node['rdfs:seeAlso'] = entry[:seeAlso] if entry[:seeAlso]
+      rdfs_classes << node
+    end
+
+    properties.each do |id, entry|
+      defn = {"@id" => namespaced(id)}
+      case entry[:range]
+      when "xsd:string"  then defn['@language'] = nil
+      when /xsd:/        then defn['@type'] = entry[:range].split(',').first
+      when nil,
+          'rdfs:Literal' then ;
+      else                    defn['@type'] = '@id'
+      end
+
+      defn['@container'] = entry[:@container] if entry[:@container]
+      defn['@type'] = entry[:@type] if entry[:@type]
+
+      term = entry[:term] || id
+      context[term] = defn unless entry[:@type] == '@null'
+
+      # Property definition
+      node = {
+        '@id' => namespaced(id),
+        '@type' => 'rdf:Property',
+        'rdfs:label' => {"en" => entry[:label].to_s},
+        'rdfs:comment' => {"en" => entry[:comment].to_s},
+      }
+      node['rdfs:subPropertyOf'] = namespaced(entry[:subClassOf]) if entry[:subClassOf]
+      node['rdfs:seeAlso'] = entry[:seeAlso] if entry[:seeAlso]
+
+      domains = entry[:domain].to_s.split(',')
+      case domains.length
+      when 0  then ;
+      when 1  then node['rdfs:domain'] = namespaced(domains.first)
+      else         node['rdfs:domain'] = {'owl:unionOf' => domains.map {|d| namespaced(d)}}
+      end
+
+      ranges = entry[:range].to_s.split(',')
+      case ranges.length
+      when 0  then ;
+      when 1  then node['rdfs:range'] = namespaced(ranges.first)
+      else         node['rdfs:range'] = {'owl:unionOf' => ranges.map {|r| namespaced(r)}}
+      end
+
+      rdfs_properties << node
+    end
+
+    datatypes.each  do |id, entry|
+      context[id] = namespaced(id) unless entry[:@type] == '@null'
+
+      # Datatype definition
+      node = {
+        '@id' => namespaced(id),
+        '@type' => 'rdfs:Datatype',
+        'rdfs:label' => {"en" => entry[:label].to_s},
+        'rdfs:comment' => {"en" => entry[:comment].to_s},
+      }
+      node['rdfs:subClassOf'] = namespaced(entry[:subClassOf]) if entry[:subClassOf]
+      node['rdfs:seeAlso'] = entry[:seeAlso] if entry[:seeAlso]
+      rdfs_datatypes << node
+    end
+
+    instances.each do |id, entry|
+      context[id] = namespaced(id) unless entry[:@type] == '@null'
+      # Instance definition
+      node = {
+        '@id' => namespaced(id),
+        '@type' => entry[:type],
+        'rdfs:label' => {"en" => entry[:label].to_s},
+        'rdfs:comment' => {"en" => entry[:comment].to_s},
+      }
+      node['rdfs:seeAlso'] = entry[:seeAlso] if entry[:seeAlso]
+
+      rdfs_instances << node
+    end
+
+    # Use separate rdfs context so as not to polute the context.
+    ontology = {
+      "@context" => rdfs_context,
+      "@id" => prefixes["jsonld"][:subClassOf],
+      "@type" => "owl:Ontology",
+      "dc": "http://purl.org/dc/terms/",
+      "owl": "http://www.w3.org/2002/07/owl#",
+      "rdf": "http://www.w3.org/1999/02/22-rdf-syntax-ns#",
+      "rdfs": "http://www.w3.org/2000/01/rdf-schema#",
+      "dc:title" => {"en" => TITLE},
+      "dc:description" => {"en" => DESCRIPTION},
+      "dc:date" => date,
+      "owl:imports" => imports,
+      "owl:versionInfo" => commit,
+      "rdfs:seeAlso" => seeAlso,
+      "rdfs_classes" => rdfs_classes,
+      "rdfs_properties" => rdfs_properties,
+      "rdfs_datatypes" => rdfs_datatypes,
+      "rdfs_instances" => rdfs_instances
+    }.delete_if {|k,v| Array(v).empty?}
+
+    {
+      "@context" => context,
+      "@graph" => ontology
+    }.to_json(JSON_STATE)
+  end
+
+  def to_html
+    json = JSON.parse(to_jsonld)
+    eruby = Erubis::Eruby.new(File.read("template.html"))
+    eruby.result(ont: json['@graph'], context: json['@context'])
+  end
+
+  def to_ttl
+    output = []
+
+    prefixes = {
+      "dc"   => {subClassOf: "http;//purl.org/dc/terms/"},
+      "owl"  => {subClassOf: "http://www.w3.org/2002/07/owl#"},
+      "rdf"  => {subClassOf: "http://www.w3.org/1999/02/22-rdf-syntax-ns#"},
+      "rdfs" => {subClassOf: "http://www.w3.org/2000/01/rdf-schema#"},
+    }.merge(@prefixes).dup
+    prefixes.each {|id, entry| output << "@prefix #{id}: <#{entry[:subClassOf]}> ."}
+
+    output << "\n# JSON-LD Ontology definition"
+    output << "jsonld: a owl:Ontology;"
+    output << %(  dc:title "#{TITLE}"@en;)
+    output << %(  dc:description """#{DESCRIPTION}"""@en;)
+    output << %(  dc:date "#{date}"^^xsd:date;)
+    output << %(  dc:imports #{imports.map {|i| '<' + i + '>'}.join(", ")};) if imports
+    output << %(  owl:versionInfo <#{commit}>;)
+    output << %(  rdfs:seeAlso #{seeAlso.map {|i| '<' + i + '>'}.join(", ")};)
+    output << "  .\n"
+
+    unless @classes.empty?
+      output << "\n# Class definitions"#{
+      @classes.each do |id, entry|
+        output << "jsonld:#{id} a rdfs:Class;"
+        output << %(  rdfs:label "#{entry[:label]}"@en;)
+        output << %(  rdfs:comment """#{entry[:comment]}"""@en;)
+        output << %(  rdfs:subClassOf #{namespaced(entry[:subClassOf])};) if entry[:subClassOf]
+        output << %(  rdfs:seeAlso <#{entry[:seeAlso]}>;) if entry[:seeAlso]
+        output << %(  rdfs:isDefinedBy jsonld: .)
+      end
+    end
+
+    unless @properties.empty?
+      output << "\n# Property definitions"
+      @properties.each do |id, entry|
+        output << "jsonld:#{id} a rdf:Property;"
+        output << %(  rdfs:label "#{entry[:label]}"@en;)
+        output << %(  rdfs:comment """#{entry[:comment]}"""@en;)
+        output << %(  rdfs:subPropertyOf #{namespaced(entry[:subClassOf])};) if entry[:subClassOf]
+        domains = entry[:domain].to_s.split(',')
+        case domains.length
+        when 0  then ;
+        when 1  then output << %(  rdfs:domain #{namespaced(entry[:domain])};)
+        else
+          output << %(  rdfs:domain [ owl:unionOf (#{domains.map {|d| namespaced(d)}.join(' ')})];)
+        end
+
+        ranges = entry[:range].to_s.split(',')
+        case ranges.length
+        when 0  then ;
+        when 1  then output << %(  rdfs:range #{namespaced(entry[:range])};)
+        else
+          output << %(  rdfs:range [ owl:unionOf (#{ranges.map {|d| namespaced(d)}.join(' ')})];)
+        end
+        output << %(  rdfs:seeAlso <#{entry[:seeAlso]}>;) if entry[:seeAlso]
+        output << %(  rdfs:isDefinedBy jsonld: .)
+      end
+    end
+
+    unless @datatypes.empty?
+      output << "\n# Datatype definitions"
+      @datatypes.each do |id, entry|
+        output << "jsonld:#{id} a rdfs:Datatype;"
+        output << %(  rdfs:label "#{entry[:label]}"@en;)
+        output << %(  rdfs:comment """#{entry[:comment]}"""@en;)
+        output << %(  rdfs:subClassOf #{namespaced(entry[:subClassOf])};) if entry[:subClassOf]
+        output << %(  rdfs:seeAlso <#{entry[:seeAlso]}>;) if entry[:seeAlso]
+        output << %(  rdfs:isDefinedBy jsonld: .)
+      end
+    end
+
+    unless @instances.empty?
+      output << "\n# Instance definitions"
+      @instances.each do |id, entry|
+        output << "jsonld:#{id} a #{namespaced(entry[:type])};"
+        output << %(  rdfs:label "#{entry[:label]}"@en;)
+        output << %(  rdfs:comment """#{entry[:comment]}"""@en;)
+        output << %(  rdfs:seeAlso <#{entry[:seeAlso]}>;) if entry[:subClassOf]
+        output << %(  rdfs:isDefinedBy jsonld: .)
+      end
+    end
+
+    output.join("\n")
+  end
+end
+
+options = {
+  output: $stdout
+}
+
+OPT_ARGS = [
+  ["--format", "-f",  GetoptLong::REQUIRED_ARGUMENT,"Output format, default #{options[:format].inspect}"],
+  ["--output", "-o",  GetoptLong::REQUIRED_ARGUMENT,"Output to the specified file path"],
+  ["--quiet",         GetoptLong::NO_ARGUMENT,      "Supress most output other than progress indicators"],
+  ["--help", "-?",    GetoptLong::NO_ARGUMENT,      "This message"]
+]
+def usage
+  STDERR.puts %{Usage: #{$0} [options] URL ...}
+  width = OPT_ARGS.map do |o|
+    l = o.first.length
+    l += o[1].length + 2 if o[1].is_a?(String)
+    l
+  end.max
+  OPT_ARGS.each do |o|
+    s = "  %-*s  " % [width, (o[1].is_a?(String) ? "#{o[0,2].join(', ')}" : o[0])]
+    s += o.last
+    STDERR.puts s
+  end
+  exit(1)
+end
+
+opts = GetoptLong.new(*OPT_ARGS.map {|o| o[0..-2]})
+
+opts.each do |opt, arg|
+  case opt
+  when '--format'       then options[:format] = arg.to_sym
+  when '--output'       then options[:output] = File.open(arg, "w")
+  when '--quiet'        then options[:quiet] = true
+  when '--help'         then usage
+  end
+end
+
+vocab = Vocab.new
+case options[:format]
+when :jsonld  then options[:output].puts(vocab.to_jsonld)
+when :ttl     then options[:output].puts(vocab.to_ttl)
+when :html    then options[:output].puts(vocab.to_html)
+else
+  [:jsonld, :ttl, :html].each do |format|
+    fn = {jsonld: "json-ld.jsonld", ttl: "json-ld.ttl", html: "json-ld.html"}[format]
+    File.open(fn, "w") do |output|
+      output.puts(vocab.send("to_#{format}".to_sym))
+    end
+  end
+end

--- a/ns/template.html
+++ b/ns/template.html
@@ -1,0 +1,151 @@
+<html lang="en">
+  <head>
+    <meta charset='utf-8'/>
+    <title><%= ont["dc:title"]["en"] %></title>
+    <base href="<%=context['jsonld']%>" />
+    <script class="remove" src="https://www.w3.org/Tools/respec/respec-w3c-common"></script>
+    <link href="http://www.w3.org/StyleSheets/TR/W3C-ED" rel="stylesheet">
+    <style type="text/css">
+      dl.terms dt {
+        float: left;
+        clear: left;
+        width: 17vw;
+      }
+      dl.terms dd:after {
+          content: '';
+          display: block;
+          clear: both;
+          margin-bottom: 5px;
+      }
+      table.rdfs-definition td {vertical-align: top;}
+      .bold {font-weight: bold;}
+    </style>
+  </head>
+  <body resource="<%=context['jsonld']%>" typeof="owl:Ontology" prefix="jsonld: <%=context['jsonld']%>">
+    <h1 property="rdfs:label"><%= ont["dc:title"]["en"] %></h1>
+    <p><a href="http://www.w3.org/"><img src="http://www.w3.org/Icons/w3c_home" alt="W3C" height="48" width="72"></a></p>
+    <p property="rdfs:comment">This is a vocabulary document and is used to achieve certain features of the JSON-LD language.</p>
+    <p>Alternate versions of the vocabulary definition exist in
+      <a rel="alternate" href="jsonld.ttl">Turtle</a> and
+      <a rel="alternate" href="jsonld.jsonld">JSON-LD</a>,
+      which also includes the <code>@context</code> required for metadata descriptions.
+      <!--These versions may also be retrieved from <code>FIXME</code> using an appropiate HTTP <em>Accept</em> header.-->
+    </p>
+    <dl>
+      <dt>Published:</dt><dd><time property="dc:date"><%=ont["dc:date"]%></time></dd>
+      <%- unless Array(ont["owl:imports"]).empty?%>
+      <dt>Imports:</dt>
+      <%- Array(ont["owl:imports"]).each do |ref| %>
+        <dd><a href="<%=ref%>" property="owl:imports"><%=ref%></a></dd>
+      <%- end -%>
+      <%- end -%>
+      <dt>Version Info:</dt>
+      <dd><a href="<%=ont['owl:versionInfo']%>" property="owl:versionInfo"><%=ont['owl:versionInfo']%></a></dd>
+      <dt>See Also:</dt>
+      <%- Array(ont["rdfs:seeAlso"]).each do |ref| %>
+        <dd><a href="<%=ref%>" property="rdfs:seeAlso"><%=ref%></a></dd>
+      <% end %>
+    </dl>
+    <section>
+      <h2>Prefix Definitions</h2>
+      <dl class="terms">
+        <%- context.keys.sort.each do |term|%>
+        <%- defn = context[term] %>
+        <%- next unless defn.is_a?(String) %>
+        <dt><%= term %></dt>
+        <dd><%= defn %></dd>
+        <%- end %>
+      </dl>
+    </section>
+    <%-
+      [{
+        heading: "Class Definitions",
+        key: "rdfs_classes"
+      }, {
+        heading: "Property Definitions",
+        key: "rdfs_properties"
+      }, {
+        heading: "Datatype Definitions",
+        key: "rdfs_datatypes"
+      }, {
+        heading: "Instance Definitions",
+        key: "rdfs_instances"
+      }].each do |sect|
+        next unless ont[sect[:key]]
+    %>
+    <section>
+      <h2><%= sect[:heading] %></h2>
+      <p>The following are <%= sect[:heading].downcase %> in the <code>jsonld</code> namespace:</p>
+      <table class="rdfs-definition">
+        <%- Array(ont[sect[:key]]).each do |defn| -%>
+        <tr id="<%= defn['@id'][7..-1] %>">
+          <td class="bold"><%= defn['@id'][7..-1] %></td>
+          <td resource="<%= defn['@id'] %>" typeof="<%= Array(defn['@type']).join(" ") %>">
+            <em property="rdfs:label"><%= defn['rdfs:label']['en'] %></em>
+            <span class="permalink"><a href="#<%= defn['@id'][7..-1] %>" aria-label="Permalink for <%= defn['rdfs:label']['en'] %>" title="Permalink for <%= defn['rdfs:label']['en'] %>"><span>§</span></a></span>
+            <p property="rdfs:comment"><%= defn['rdfs:comment']['en'] %></p>
+            <%- if defn[:subClassOf] %>
+            <%- end %>
+            <p>You can read more about this feature in the <a property="rdfs:seeAlso" href="<%=defn[:subClassOf]%>">JSON-LD Syntax specification</a>.</p>
+            
+            <span property="rdfs:isDefinedBy" resource="jsonld:"></span>
+            <%- if %w(rdfs:subClassOf rdfs:subPropertyOf rdfs:range rdfs:domain).any? { |p| defn.has_key?(p)} %>
+              <dl class="terms">
+                <%- %w(rdfs:subClassOf rdfs:subPropertyOf rdfs:range rdfs:domain).each do |p| %>
+                  <%- if defn.has_key?(p) %>
+                  <dt><%= p %></dt>
+                  <%- Array(defn[p]).each do |v| %>
+                    <%if- v.is_a?(Array) && v.first == 'owl:unionOf' %>
+                      <dd property="<%= p %>" resource="_:">
+                        Union of
+                        <% v.last.each do |c| %>
+                        <span property="owl:unionOf" inlist=true resource="<%= c %>"><%= c %></span>
+                        <% end%>
+                      </dd>
+                    <%- else %>
+                      <dd property="<%= p %>" resource="<%= v %>"><%= v %></dd>
+                    <%- end %>
+                  <%- end %>
+                  <%- end %>
+                <%- end %>
+              </dl>
+            <% end %>
+          </td>
+        </tr>
+        <%- end -%>
+      </table>
+    </section>
+    <%- end%>
+    <section>
+      <h2>Term Definitions</h2>
+      <dl class="terms">
+        <%- context.keys.sort.each do |term|%>
+        <%- defn = context[term] %>
+        <%- next if defn.is_a?(String) %>
+        <dt><%= term %></dt>
+        <dd>
+          <%- if defn['@id'] %>
+            <%= defn['@id'] %>
+          <%- elsif defn['@reverse'] %>
+            reverse of <%= defn['@reverse'] %>
+          <%- else %>
+            <%= term %>
+          <%- end %>
+          <%- if defn.is_a?(Hash) && defn['@type'] %>
+            with string values interpreted as <%= defn['@type'] %>
+          <%- end%>
+          <%- if defn.is_a?(Hash) && defn['@container'] %>
+            <%- if defn['@container'] == '@language' %>
+              with object values interpreted as language-specific, indexed by language
+            <%- elsif defn['@container'] == '@index' %>
+              with object values interpreted indexed by index
+            <%- else %>
+              with array values interpreted as <%= defn['@container'] %>
+            <%- end %>
+          <%- end%>
+        </dd>
+        <%- end %>
+      </dl>
+    </section>
+  </body>
+</html>

--- a/ns/vocab.csv
+++ b/ns/vocab.csv
@@ -1,0 +1,10 @@
+id,type,label,subClassOf,domain,range,@type,@container,ForwardMultiplicity,ReverseMultiplicity,seeAlso,term,comment
+,rdfs:seeAlso,,http://www.w3.org/TR/json-ld11,,,,,,,,,
+rdf,prefix,,http://www.w3.org/1999/02/22-rdf-syntax-ns#,,,,,,,,,
+rdfs,prefix,,http://www.w3.org/2000/01/rdf-schema#,,,,,,,,,
+jsonld,prefix,,http://www.w3.org/ns/json-ld#,,,,,,,,,
+xsd,prefix,,http://www.w3.org/2001/XMLSchema#,,,,,,,,,
+context,rdf:Property,context,,,,,,,,http://www.w3.org/TR/json-ld11/#interpreting-json-as-json-ld,,This is a vocabulary document and is used to achieve certain features of the JSON-LD language.
+expanded,rdf:Property,expanded,,,,,,,,https://www.w3.org/TR/json-ld11/#iana-considerations,,This link relation is used to reference a JSON-LD context from a JSON document so that it can be interpreted as JSON-LD.
+compacted,rdf:Property,compacted,,,,,,,,https://www.w3.org/TR/json-ld11/#iana-considerations,,This profile URI is used to request or specify expanded JSON-LD document form.
+flattened,rdf:Property,flattened,,,,,,,,https://www.w3.org/TR/json-ld11/#iana-considerations,,This profile URI is used to request or specify flattened JSON-LD document form.

--- a/ns/vocab.csv
+++ b/ns/vocab.csv
@@ -4,7 +4,7 @@ rdf,prefix,,http://www.w3.org/1999/02/22-rdf-syntax-ns#,,,,,,,,,
 rdfs,prefix,,http://www.w3.org/2000/01/rdf-schema#,,,,,,,,,
 jsonld,prefix,,http://www.w3.org/ns/json-ld#,,,,,,,,,
 xsd,prefix,,http://www.w3.org/2001/XMLSchema#,,,,,,,,,
-context,rdf:Property,context,,,,,,,,http://www.w3.org/TR/json-ld11/#interpreting-json-as-json-ld,,This is a vocabulary document and is used to achieve certain features of the JSON-LD language.
-expanded,rdf:Property,expanded,,,,,,,,https://www.w3.org/TR/json-ld11/#iana-considerations,,This link relation is used to reference a JSON-LD context from a JSON document so that it can be interpreted as JSON-LD.
-compacted,rdf:Property,compacted,,,,,,,,https://www.w3.org/TR/json-ld11/#iana-considerations,,This profile URI is used to request or specify expanded JSON-LD document form.
-flattened,rdf:Property,flattened,,,,,,,,https://www.w3.org/TR/json-ld11/#iana-considerations,,This profile URI is used to request or specify flattened JSON-LD document form.
+context,rdf:Property,context,,,,,,,,http://www.w3.org/TR/json-ld11/#interpreting-json-as-json-ld,,This link relation is used to reference a JSON-LD context from a JSON document so that it can be interpreted as JSON-LD.
+expanded,owl:NamedIndividual,expanded,,,,,,,,https://www.w3.org/TR/json-ld11/#iana-considerations,,This profile URI is used to request or specify expanded JSON-LD document form.
+compacted,owl:NamedIndividual,compacted,,,,,,,,https://www.w3.org/TR/json-ld11/#iana-considerations,,This profile IRI is used to request or specify compacted JSON-LD document form.
+flattened,owl:NamedIndividual,flattened,,,,,,,,https://www.w3.org/TR/json-ld11/#iana-considerations,,This profile URI is used to request or specify flattened JSON-LD document form.


### PR DESCRIPTION
Based on the version from json-ld.org, which is out of sync with what is actually published, but more correct. This version uses a script to generate the files from a spreadsheet, to allow for more easy definition of terms in the future.

The WoT group has an [extended vocabulary for defining JSON-LD contexts](https://github.com/w3c/wot-thing-description/tree/master/context) in OWL/RDFS and would like the JSON-LD namespace to include appropriate annotation properties for this.