### PR TITLE
Should probably be :TermDefinition rather than :ExpandedTermDefinition.

### DIFF
--- a/ns/template.haml
+++ b/ns/template.haml
@@ -63,11 +63,11 @@
               :term "jsonld";
               :iri &lt;http://www.w3.org/ns/json-ld#&gt;;
             ], [
-              a :ExpandedTermDefinition;
+              a :TermDefinition;
               :term "Context";
               :iri :Context
             ], [
-              a :ExpandedTermDefinition;
+              a :TermDefinition;
               :term "base";
               :iri :base;
               :type "@id"


### PR DESCRIPTION
NB: I tried to run mk_vocab.rb, but it generated more changes than just this.
I'm not sure I installed the ruby dependencies correctly,
so I chose to leave it that way.