### PR TITLE
Do not highlight example example.

### DIFF
--- a/common/typographical-conventions.html
+++ b/common/typographical-conventions.html
@@ -39,7 +39,7 @@
 <p class="note">Notes are in light green boxes with a green left border and with a "Note" header in green.
   Notes are always informative.</p>
 
-<pre class="example">
+<pre class="example nohighlight">
   Examples are in light khaki boxes, with khaki left border,
   and with a numbered "Example" header in khaki.
   Examples are always informative. The content of the example is in monospace font and may be syntax colored.


### PR DESCRIPTION
ReSpec highlights the example example as JavaScript including
highlighing non-code keywords. This makes render as plain text.